### PR TITLE
会員の登録画面の実装

### DIFF
--- a/app/assets/stylesheets/modules/_members.scss
+++ b/app/assets/stylesheets/modules/_members.scss
@@ -1,3 +1,4 @@
 * {
   box-sizing: border-box;
 }
+

--- a/app/assets/stylesheets/modules/_members.scss
+++ b/app/assets/stylesheets/modules/_members.scss
@@ -2,3 +2,64 @@
   box-sizing: border-box;
 }
 
+h1 {
+  letter-spacing: 2px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.clearfix:after{
+  content: "";
+  clear: both;
+  display: block;
+}
+
+.member-form {
+  width: 980px;
+  margin: 60px auto;
+  padding: 40px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+  &__action-btn{
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+  .new_member__field {
+    margin-top: 30px;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+    &--left {
+      float: left;
+      width: 30%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
+    &--right {
+      float: right;
+      width: 70%;
+    }
+  }
+}

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -7,5 +7,17 @@ class MembersController < ApplicationController
   end
 
   def create
+    @member = Member.new(member_params)
+    if @member.save
+      redirect_to root_path
+    else
+      render :new
+    end
   end
+
+  private
+  def member_params
+    params.require(:member).permit(:name, :tel, :birthday, :postcode, :city, :block, :building)
+  end
+
 end

--- a/app/views/members/new.html.haml
+++ b/app/views/members/new.html.haml
@@ -2,25 +2,49 @@
   %h1 会員登録
   .new_member
     = form_for @member do |f|
-      = f.label :name, "名前"
-      = f.text_field :name, class: "member-form__name", placeholder: "名前を入力してください"
-      %br/
-      = f.label :tel, "電話番号"
-      = f.text_field :tel, class: "member-form__tel", placeholder: "電話番号を入力してください"
-      %br/
-      = f.label :birthday, "誕生日"
-      = f.date_select :birthday, class: "member-form__birthday", use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1)
-      %br/
-      = f.label :postcode, "郵便番号"
-      = f.text_field :postcode, class: "member-form__postcode", placeholder: "郵便番号を入力してください"
-      %br/
-      = f.label :city, "都道府県"
-      = f.text_field :city, class: "member-form__city", placeholder:"都道府県を入力してください"
-      %br/
-      = f.label :block, "市町村"
-      = f.text_field :block, class: "member-form__block", placeholder:"市町村を入力してください"
-      %br/
-      = f.label :building, "番地"
-      = f.text_field :building, class: "member-form__building", placeholder:"番地を入力してください"
-      %br/
-      = f.submit "次の項目へ", class: "member-form__action-btn"
+      .new_member__field
+        .new_member__field--left
+          = f.label :name, "名前"
+        .new_member__field--right
+          = f.text_field :name, class: "member-form__name", placeholder: "名前を入力してください"
+
+      .new_member__field.clearfix
+        .new_member__field--left
+          = f.label :tel, "電話番号"
+        .new_member__field--right
+          = f.text_field :tel, class: "member-form__tel", placeholder: "電話番号を入力してください"
+
+      .new_member__field.clearfix
+        .new_member__field--left
+          = f.label :birthday, "誕生日"
+        .new_member__field--right
+          = f.date_select :birthday, class: "member-form__birthday", use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1)
+
+      .new_member__field.clearfix
+        .new_member__field--left
+          = f.label :postcode, "郵便番号"
+        .new_member__field--right
+          = f.text_field :postcode, class: "member-form__postcode", placeholder: "郵便番号を入力してください"
+
+      .new_member__field.clearfix
+        .new_member__field--left
+          = f.label :city, "都道府県"
+        .new_member__field--right
+          = f.text_field :city, class: "member-form__city", placeholder:"都道府県を入力してください"
+      
+      .new_member__field.clearfix
+        .new_member__field--left
+          = f.label :block, "市町村"
+        .new_member__field--right
+          = f.text_field :block, class: "member-form__block", placeholder:"市町村を入力してください"
+
+      .new_member__field.clearfix
+        .new_member__field--left
+          = f.label :building, "番地"
+        .new_member__field--right
+          = f.text_field :building, class: "member-form__building", placeholder:"番地を入力してください"
+      
+      .new_member__field.clearfix
+        .new_member__field--left
+          = f.submit "次の項目へ", class: "member-form__action-btn"
+        .new_member__field--right

--- a/app/views/members/new.html.haml
+++ b/app/views/members/new.html.haml
@@ -23,4 +23,4 @@
       = f.label :building, "番地"
       = f.text_field :building, class: "member-form__building", placeholder:"番地を入力してください"
       %br/
-      = f.submit "登録する", class: "member-form__action-btn"
+      = f.submit "次の項目へ", class: "member-form__action-btn"

--- a/app/views/members/new.html.haml
+++ b/app/views/members/new.html.haml
@@ -1,50 +1,50 @@
 .member-form
-  %h1 会員登録
+  %h1 新規会員登録
   .new_member
     = form_for @member do |f|
       .new_member__field
         .new_member__field--left
-          = f.label :name, "名前"
+          = f.label :name, "名前", class: 'member-form__label'
         .new_member__field--right
-          = f.text_field :name, class: "member-form__name", placeholder: "名前を入力してください"
+          = f.text_field :name, class: "member-form__name member-form__input", placeholder: "名前を入力してください"
 
       .new_member__field.clearfix
         .new_member__field--left
-          = f.label :tel, "電話番号"
+          = f.label :tel, "電話番号", class: 'member-form__label'
         .new_member__field--right
-          = f.text_field :tel, class: "member-form__tel", placeholder: "電話番号を入力してください"
+          = f.text_field :tel, class: "member-form__tel member-form__input", placeholder: "電話番号を入力してください"
 
       .new_member__field.clearfix
         .new_member__field--left
-          = f.label :birthday, "誕生日"
+          = f.label :birthday, "誕生日", class: 'member-form__label'
         .new_member__field--right
-          = f.date_select :birthday, class: "member-form__birthday", use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1)
+          = f.date_select :birthday, class: "member-form__birthday member-form__input", use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1)
 
       .new_member__field.clearfix
         .new_member__field--left
-          = f.label :postcode, "郵便番号"
+          = f.label :postcode, "郵便番号", class: 'member-form__label'
         .new_member__field--right
-          = f.text_field :postcode, class: "member-form__postcode", placeholder: "郵便番号を入力してください"
+          = f.text_field :postcode, class: "member-form__postcode member-form__input", placeholder: "郵便番号を入力してください"
 
       .new_member__field.clearfix
         .new_member__field--left
-          = f.label :city, "都道府県"
+          = f.label :city, "都道府県", class: 'member-form__label'
         .new_member__field--right
-          = f.text_field :city, class: "member-form__city", placeholder:"都道府県を入力してください"
+          = f.text_field :city, class: "member-form__city member-form__input", placeholder:"都道府県を入力してください"
       
       .new_member__field.clearfix
         .new_member__field--left
-          = f.label :block, "市町村"
+          = f.label :block, "市町村", class: 'member-form__label'
         .new_member__field--right
-          = f.text_field :block, class: "member-form__block", placeholder:"市町村を入力してください"
+          = f.text_field :block, class: "member-form__block member-form__input", placeholder:"市町村を入力してください"
 
       .new_member__field.clearfix
         .new_member__field--left
-          = f.label :building, "番地"
+          = f.label :building, "番地", class: 'member-form__label'
         .new_member__field--right
-          = f.text_field :building, class: "member-form__building", placeholder:"番地を入力してください"
+          = f.text_field :building, class: "member-form__building member-form__input", placeholder:"番地を入力してください"
       
       .new_member__field.clearfix
         .new_member__field--left
+        .new_member__field--right
           = f.submit "次の項目へ", class: "member-form__action-btn"
-        .new_member__field--right


### PR DESCRIPTION
# What
新規会員登録から、会員登録画面に移行。登録保存ができる。
form_forを実装。しかし、次の家族テーブルを作成しネストを用い、form_forでnewとcreateアクションを実装するもエラーが発生。今回はテーブルを拡張し実装をすることに決める。
そのため、一つ前の段階である登録画面の実装でプルリクエスト。

# Why
登録画面と保存は必要な機能のため。